### PR TITLE
chore: Update worker from self-hosted to ubuntu-latest

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,7 +27,7 @@ jobs:
   pre-commit:
     runs-on:
       labels:
-        - self-hosted-default
+        - ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
The self-hosted workers are unavailable from public repositories, so we will use ubuntu-latest instead.

This fixes the pre-commit workflow.